### PR TITLE
#48 구현

### DIFF
--- a/Client/Sources/ClientApp.cpp
+++ b/Client/Sources/ClientApp.cpp
@@ -8,7 +8,7 @@ class Client : public kepler::Application
 {
 public:
 	Client()
-		: Application(kepler::eGraphicsAPI::DirectX11)
+		: Application(kepler::eGraphicsAPI::DirectX11, kepler::WindowProperty(std::string("Test")))
 	{
 		PushLayer(new InstLayer);
 		PushOverlay(new kepler::RenderProfiler);

--- a/Kepler/Core/Application.cpp
+++ b/Kepler/Core/Application.cpp
@@ -15,13 +15,13 @@ namespace kepler {
 	Application* Application::s_pInstance = nullptr;
 
 	// Initialize Core resources
-	Application::Application(eGraphicsAPI api)
+	Application::Application(eGraphicsAPI api, const WindowProperty& props)
 	{
 		kepler::Log::Init();
 		kepler::Audio::Init();
 
 		IGraphicsAPI::SetAPI(api);
-		m_pWindow = std::unique_ptr<IWindow>(IWindow::Create());
+		m_pWindow = std::unique_ptr<IWindow>(IWindow::Create(props));
 
 		// bind this->OnEvent
 		m_pWindow->SetEventCallback(std::bind(&Application::OnEvent, this, std::placeholders::_1));

--- a/Kepler/Core/Application.h
+++ b/Kepler/Core/Application.h
@@ -23,7 +23,7 @@ namespace kepler {
 		bool m_bIsRunning;
 
 	protected:
-		Application(eGraphicsAPI api);
+		Application(eGraphicsAPI api, const WindowProperty& props = WindowProperty());
 
 	public:
 		~Application();

--- a/Kepler/Platform/DirectX11/DX11Context.cpp
+++ b/Kepler/Platform/DirectX11/DX11Context.cpp
@@ -35,22 +35,22 @@ bool kepler::DX11Context::Init(const WindowData& data)
 	m_bVSync = data.bVSync;
 
 	// Start Init Adapter Info
-	IDXGIFactory* factory = nullptr;
-	if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory)))
+	IDXGIFactory* pFactory = nullptr;
+	if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory)))
 	{
 		KEPLER_ASSERT(false, "Fail to Initialize IDXGIFactory");
 		return false;
 	}
-	IDXGIAdapter* adapter = nullptr;
-	if (FAILED(factory->EnumAdapters(0, &adapter)))
+	IDXGIAdapter* pAdapter = nullptr;
+	if (FAILED(pFactory->EnumAdapters(0, &pAdapter)))
 	{
 		KEPLER_ASSERT(false, "Fail to Initialize IDXGIAdapter");
 		return false;
 	}
 	DXGI_ADAPTER_DESC adapterDesc;
-	if (FAILED(adapter->GetDesc(&adapterDesc)))
+	if (FAILED(pAdapter->GetDesc(&adapterDesc)))
 	{
-		KEPLER_ASSERT(false, "Fail to Initialize DXGI_ADAPTER_DESC");
+		KEPLER_ASSERT(false, "Fail to Get DXGI Adapter Description(DXGI_ADAPTER_DESC)");
 		return false;
 	}
 	
@@ -69,10 +69,10 @@ bool kepler::DX11Context::Init(const WindowData& data)
 	KEPLER_CORE_INFO("Video Card Memory : {0}", videoCardMemory);
 	KEPLER_CORE_INFO("Video Card Description : {0}", videoCardDescription);
 
-	adapter->Release();
-	adapter = 0;
-	factory->Release();
-	factory = 0;
+	pAdapter->Release();
+	pAdapter = nullptr;
+	pFactory->Release();
+	pFactory = nullptr;
 	// End Init Adapter Info
 
 	DXGI_SWAP_CHAIN_DESC scDesc{};

--- a/Kepler/Platform/DirectX11/DX11Context.cpp
+++ b/Kepler/Platform/DirectX11/DX11Context.cpp
@@ -34,6 +34,47 @@ bool kepler::DX11Context::Init(const WindowData& data)
 {
 	m_bVSync = data.bVSync;
 
+	// Start Init Adapter Info
+	IDXGIFactory* factory = nullptr;
+	if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory)))
+	{
+		KEPLER_ASSERT(false, "Fail to Initialize IDXGIFactory");
+		return false;
+	}
+	IDXGIAdapter* adapter = nullptr;
+	if (FAILED(factory->EnumAdapters(0, &adapter)))
+	{
+		KEPLER_ASSERT(false, "Fail to Initialize IDXGIAdapter");
+		return false;
+	}
+	DXGI_ADAPTER_DESC adapterDesc;
+	if (FAILED(adapter->GetDesc(&adapterDesc)))
+	{
+		KEPLER_ASSERT(false, "Fail to Initialize DXGI_ADAPTER_DESC");
+		return false;
+	}
+	
+	int vendorId = adapterDesc.VendorId;
+	int videoCardMemory = (int)(adapterDesc.DedicatedVideoMemory / 1024 / 1024);
+	char videoCardDescription[128] = { 0, };
+	size_t stringLength = 0;
+	if (wcstombs_s(&stringLength, videoCardDescription, 128, adapterDesc.Description, 128) != 0)
+	{
+		KEPLER_ASSERT(false, "Fail to Get Video Card Description");
+		return false;
+	}
+
+	// Logging Adapter Info
+	KEPLER_CORE_INFO("Video Card Vendor Id : {0}", vendorId);
+	KEPLER_CORE_INFO("Video Card Memory : {0}", videoCardMemory);
+	KEPLER_CORE_INFO("Video Card Description : {0}", videoCardDescription);
+
+	adapter->Release();
+	adapter = 0;
+	factory->Release();
+	factory = 0;
+	// End Init Adapter Info
+
 	DXGI_SWAP_CHAIN_DESC scDesc{};
 	scDesc.BufferCount = 2;
 	scDesc.BufferDesc.Width = 0;

--- a/Kepler/kepch.h
+++ b/Kepler/kepch.h
@@ -32,6 +32,9 @@
 // for DirectX
 #ifdef KEPLER_GRAPHICS_API_DIRECTX
 #pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3dcompiler.lib")
+
 #include <d3d11.h>
 #include <d3dcompiler.h>
 #endif


### PR DESCRIPTION
Application 프로세스명을 Client::Application의 생성자를 이용하여 변경 가능합니다.  현재 "Test"로 변경되었습니다.
IDXGIFactory, IDXGIAdapter 를 이용하여 GPU 정보를 받아오는 코드 DX11Context에 작성하였습니다.

현재 Vendor Id, Memory, Description 출력하고 있습니다.
단, CPU 정보의 경우 어뎁터에서 찾을 수 없으므로 일단 보류하였습니다. 